### PR TITLE
Fix fork run path in WandBLoader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ wheels/
 
 .env
 .neptune/
+wandb/
+exports/

--- a/src/neptune_exporter/loaders/wandb_loader.py
+++ b/src/neptune_exporter/loaders/wandb_loader.py
@@ -196,8 +196,9 @@ class WandBLoader(DataLoader):
                 else:
                     step_int = 0
 
-                # W&B fork format: entity/project/run_id?_step=step
-                fork_from = f"{self.entity}/{sanitized_project}/{parent_run_id}?_step={step_int}"
+                # W&B fork format: run_id?_step=step
+                # https://docs.wandb.ai/models/runs/forking
+                fork_from = f"{parent_run_id}?_step={step_int}"
                 init_kwargs["fork_from"] = fork_from
                 self._logger.info(
                     f"Creating forked run '{run_name}' from parent {parent_run_id} at step {step_int}"

--- a/tests/unit/test_wandb_loader.py
+++ b/tests/unit/test_wandb_loader.py
@@ -143,7 +143,7 @@ def test_create_run_with_parent(mock_init):
     # Check fork_from parameter
     call_kwargs = mock_init.call_args[1]
     assert "fork_from" in call_kwargs
-    assert "wandb-run-parent" in call_kwargs["fork_from"]
+    assert call_kwargs["fork_from"] == "wandb-run-parent?_step=0"
 
 
 def test_upload_parameters():


### PR DESCRIPTION
Fixes the path forking runs in Weights and Biases loader. Currently, when uploading forked runs, we get the error:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
fork_from
  Value error, Could not parse passed run moment string 'poolside/REDACTED/yiiwciet?_step=39500', expected format '<run>?<metric>=<numeric_value>'. Currently, only the metric '_step' is supported. Example: 'ans3bsax?_step=123'. [type=value_error, input_value='poolside/REDACTED/yiiwciet?_step=39500', input_type=str]
```

The current code prefixes entity and project name, but that is actually not required. See https://docs.wandb.ai/models/runs/forking.