### PR TITLE
Add pytest-dotenv and isolate test logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ wheels/
 .neptune/
 wandb/
 exports/
+tests/logs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
     "neptune-scale==0.27.0",
     "pre-commit>=4.3.0,<5.0.0",
     "pytest>=8.4.2,<9.0.0",
+    "pytest-dotenv>=0.5.2,<1.0.0",
     "ruff>=0.13.2,<1.0.0",
 ]
 
@@ -46,4 +47,8 @@ packages = 'neptune_exporter'
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-addopts = "-s"
+filterwarnings = [
+    "ignore:A newer version of lightning-sdk is available.*:UserWarning",
+    "ignore:jsonschema.RefResolver is deprecated.*:DeprecationWarning",
+    "ignore:The filesystem tracking backend.*:FutureWarning",
+]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,5 +1,17 @@
+from datetime import datetime
+from pathlib import Path
+
 from click.testing import CliRunner
 from neptune_exporter.main import cli
+
+
+_TEST_LOG_STAMP = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def _test_log_file() -> str:
+    log_dir = Path(__file__).resolve().parents[1] / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return str(log_dir / f"neptune_exporter_{_TEST_LOG_STAMP}.log")
 
 
 def test_main_rejects_empty_project_ids():
@@ -7,17 +19,20 @@ def test_main_rejects_empty_project_ids():
     runner = CliRunner()
 
     # Test with empty string
-    result = runner.invoke(cli, ["export", "-p", ""])
+    result = runner.invoke(cli, ["export", "-p", "", "--log-file", _test_log_file()])
     assert result.exit_code != 0
     assert "Project ID cannot be empty" in result.output
 
     # Test with whitespace-only string
-    result = runner.invoke(cli, ["export", "-p", "   "])
+    result = runner.invoke(cli, ["export", "-p", "   ", "--log-file", _test_log_file()])
     assert result.exit_code != 0
     assert "Project ID cannot be empty" in result.output
 
     # Test with multiple project IDs where one is empty
-    result = runner.invoke(cli, ["export", "-p", "valid-project", "-p", ""])
+    result = runner.invoke(
+        cli,
+        ["export", "-p", "valid-project", "-p", "", "--log-file", _test_log_file()],
+    )
     assert result.exit_code != 0
     assert "Project ID cannot be empty" in result.output
 
@@ -27,6 +42,8 @@ def test_main_accepts_valid_project_ids():
     runner = CliRunner()
 
     # Test with valid project ID (this will fail later due to missing API token, but not due to validation)
-    result = runner.invoke(cli, ["export", "-p", "valid-project"])
+    result = runner.invoke(
+        cli, ["export", "-p", "valid-project", "--log-file", _test_log_file()]
+    )
     # Should not fail due to empty project ID validation
     assert "Project ID cannot be empty" not in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -1997,6 +1997,7 @@ dev = [
     { name = "neptune-scale" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-dotenv" },
     { name = "ruff" },
 ]
 
@@ -2024,6 +2025,7 @@ dev = [
     { name = "neptune-scale", specifier = "==0.27.0" },
     { name = "pre-commit", specifier = ">=4.3.0,<5.0.0" },
     { name = "pytest", specifier = ">=8.4.2,<9.0.0" },
+    { name = "pytest-dotenv", specifier = ">=0.5.2,<1.0.0" },
     { name = "ruff", specifier = ">=0.13.2,<1.0.0" },
 ]
 
@@ -2745,6 +2747,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-dotenv"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/b0/cafee9c627c1bae228eb07c9977f679b3a7cb111b488307ab9594ba9e4da/pytest-dotenv-0.5.2.tar.gz", hash = "sha256:2dc6c3ac6d8764c71c6d2804e902d0ff810fa19692e95fe138aefc9b1aa73732", size = 3782, upload-time = "2020-06-16T12:38:03.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/da/9da67c67b3d0963160e3d2cbc7c38b6fae342670cc8e6d5936644b2cf944/pytest_dotenv-0.5.2-py3-none-any.whl", hash = "sha256:40a2cece120a213898afaa5407673f6bd924b1fa7eafce6bda0e8abffe2f710f", size = 3993, upload-time = "2020-06-16T12:38:01.139Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Summary
- add pytest-dotenv to dev dependencies and configure pytest to filter noisy warnings instead of running with `-s`
- redirect CLI tests to a timestamped log file inside a gitignored `tests/logs` directory so neptune_exporter logs no longer clutter the repo
