### PR TITLE
add GoodSeed loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     
     - name: Install dependencies
       run: |
-        uv sync --dev --extra zenml --extra litlogger --extra minfx --extra mlflow --extra wandb
+        uv sync --dev --extra zenml --extra litlogger --extra minfx --extra mlflow --extra wandb --extra goodseed
     
     - name: Run pre-commit
       run: |

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Neptune Exporter is a CLI tool to move Neptune experiments (version `2.x` or `3.x`) to disk as parquet and files, with an option to load them into the following alternative tools:
 
 - Comet
+- GoodSeed
 - Lightning AI
 - Minfx
 - MLflow
@@ -31,6 +32,7 @@ Neptune Exporter is a CLI tool to move Neptune experiments (version `2.x` or `3.
   - Comet workspace and API key, set with `COMET_WORKSPACE`/`--comet-workspace` and `COMET_API_KEY`/`--comet-api-key`.
   - Lightning AI LitLogger requires auth credentials (set via `lightning login` or `--litlogger-user-id` and `--litlogger-api-key`). Optionally specify `--litlogger-owner` for the user or organization name where teamspaces will be created (defaults to the authenticated user).
   - Minfx project and API token, set with `MINFX_PROJECT`/`--minfx-project` and `MINFX_API_TOKEN`/`--minfx-api-token`.
+  - GoodSeed: no credentials needed (local storage). Optionally set `GOODSEED_HOME`/`--goodseed-home` to override the data directory and `GOODSEED_PROJECT`/`--goodseed-project` to override the project name.
   - Pluto SDK: install [`pluto-ml`](https://github.com/Trainy-ai/pluto) (or use `--extra pluto` during `uv sync`). Authenticate via `pluto login <api-key>` or set `PLUTO_API_KEY` environment variable. See the [Pluto repo](https://github.com/Trainy-ai/pluto) and the [Pluto project page](https://pluto.trainy.ai).
 
 ## Installation
@@ -56,6 +58,7 @@ uv sync --extra mlflow --extra wandb --extra zenml
 
 Available optional dependencies:
 - `cometml` - for Comet loader
+- `goodseed` - for GoodSeed loader
 - `litlogger` - for Lightning AI LitLogger loader
 - `minfx` - for Minfx loader
 - `mlflow` - for MLflow loader
@@ -216,6 +219,12 @@ Model version export is derived from selected models (all versions for selected 
     --data-path ./exports/data \
     --files-path ./exports/files
 
+  # GoodSeed (local)
+  uv run neptune-exporter load \
+    --loader goodseed \
+    --data-path ./exports/data \
+    --files-path ./exports/files
+
   # LitLogger
   uv run lightning login && \
   uv run neptune-exporter load \
@@ -273,6 +282,9 @@ Model version export is derived from selected models (all versions for selected 
 
   > [!NOTE]
   > For Minfx, the `--step-multiplier` option is not needed since Neptune v2 natively supports float steps. The loader recreates runs in a Neptune-compatible backend and stores the original run ID in `import/original_run_id` for tracking and duplicate prevention.
+
+  > [!NOTE]
+  > For GoodSeed, no authentication or server is needed. Data is written directly to local SQLite files. Use `goodseed serve` to view imported runs in the browser. GoodSeed uses integer steps, so use `--step-multiplier` if your Neptune steps contain decimals. Files and histograms are not supported and will be skipped with a warning.
 
   > [!NOTE]
   > For Pluto, the loader uses decimal steps natively (no `--step-multiplier` needed). Authentication is configured via `--pluto-api-key` option or `PLUTO_API_KEY` environment variable.
@@ -342,6 +354,12 @@ All records use `src/neptune_exporter/model.py::SCHEMA`:
 ## Loading flow
 
 - Data is streamed run-by-run from parquet, using the same `--step-multiplier` to turn decimal steps into integers. Keep the multiplier consistent across loads when your Neptune steps are floats.
+- **GoodSeed loader**:
+  - No authentication needed. Writes directly to local SQLite files at `~/.goodseed/projects/<project>/runs/<run>.sqlite`.
+  - Neptune `project_id` is used as the GoodSeed project name (override with `--goodseed-project`). `sys/name` becomes the experiment name.
+  - Parameters are logged as configs with native types. Float series are logged as metrics (integer steps, use `--step-multiplier` for decimals). String series are logged as string series.
+  - Files, file series, and histograms are skipped (GoodSeed has no file storage). Neptune origin metadata is stored as configs under `neptune/` prefix.
+  - View imported runs with `goodseed serve`.
 - **Comet loader**:
   - Requires `--comet-workspace`. Project names derive from `project_id`, plus optional `--name-prefix`, sanitized.
   - Attribute names are sanitized to Comet format (alphanumeric + underscore, must start with letter/underscore). Metrics/series use the integer step. Files are uploaded as assets/images from `--files-path`. String series become text assets, histograms use `log_histogram_3d`.
@@ -390,6 +408,10 @@ All records use `src/neptune_exporter/model.py::SCHEMA`:
 
 ## Experiment/run mapping to targets
 
+- **GoodSeed:**
+  - Neptune `project_id` is used directly as the GoodSeed project name (e.g., `workspace/my-project`). Override with `--goodseed-project` to put all runs in a single project.
+  - Neptune's `sys/name` becomes the GoodSeed `experiment_name`. The Neptune `run_id` becomes the GoodSeed `run_name`.
+  - Neptune origin metadata (`project_id`, `run_id`, fork info) is stored as configs under `neptune/` prefix for traceability.
 - **Comet:**
   - Neptune `project_id` maps to the Comet project name (sanitized, plus optional `--name-prefix`).
   - `sys/name` becomes the Comet experiment name.
@@ -423,6 +445,7 @@ All records use `src/neptune_exporter/model.py::SCHEMA`:
 
 - **Parameters** (`float`, `int`, `string`, `bool`, `datetime`, `string_set`):
   - Comet: logged as parameters with native types (string_set → list).
+  - GoodSeed: logged as configs with native types (datetime → ISO string, string_set → comma-separated string). Skips Neptune-internal `sys/` metadata (`sys/id`, `sys/state`, `sys/owner`, `sys/size`, `sys/ping_time`, `sys/running_time`, `sys/monitoring_time`) and `monitoring/*` attributes. `sys/name` is used as the experiment name.
   - LitLogger: logged as experiment metadata (string key-value pairs, searchable/filterable in the UI).
   - Minfx: logged with native types (datetime → timestamp, string_set → StringSet). Preserves `sys/hostname`, `sys/tags`, and `sys/group_tags` from original data; other `sys/*` attributes are skipped as they're managed by Neptune.
   - MLflow: logged as params (values stringified by the client).
@@ -430,11 +453,13 @@ All records use `src/neptune_exporter/model.py::SCHEMA`:
   - W&B: logged as config with native types (string_set → list).
   - ZenML: logged as nested metadata with native types (datetime → ISO string, string_set → list); paths are split for dashboard cards.
 - **Float series** (`float_series`):
+  - GoodSeed: logged as metrics using the integer step (`--step-multiplier` applied).
   - MLflow/W&B/Comet/LitLogger: logged as metrics using the integer step (`--step-multiplier` applied). Timestamps are forwarded when present.
   - Pluto: logged with decimal steps preserved. Large step datasets are handled efficiently to avoid memory issues.
   - ZenML: aggregated into summary statistics (min/max/final/count) stored as metadata, since the Model Control Plane doesn't have native time-series visualization.
 - **String series** (`string_series`):
   - Comet: uploaded as text assets.
+  - GoodSeed: logged as string series with integer steps.
   - LitLogger: uploaded as text assets.
   - MLflow: saved as artifacts (one text file per series).
   - Minfx: logged as StringSeries with steps preserved.
@@ -443,6 +468,7 @@ All records use `src/neptune_exporter/model.py::SCHEMA`:
   - ZenML: not uploaded (skipped).
 - **Histogram series** (`histogram_series`):
   - Comet: logged as `histogram_3d`.
+  - GoodSeed: not uploaded (skipped).
   - LitLogger: uploaded as image containing a histogram plot and as artifacts containing the histogram payload.
   - Minfx: not uploaded (skipped - not supported in Neptune v2 API).
   - MLflow: uploaded as artifacts containing the histogram payload.
@@ -452,6 +478,7 @@ All records use `src/neptune_exporter/model.py::SCHEMA`:
 - **Files** (`file`) and **file series** (`file_series`):
   - Downloaded to `--files-path/<sanitized_project_id>/...` with relative paths stored in `file_value.path`.
   - Comet: uploaded as assets. Comet detects images and uploads them as images.
+  - GoodSeed: not uploaded (skipped, GoodSeed has no file storage).
   - LitLogger: uploaded as artifacts.
   - Minfx: uploaded with auto-detected file extensions (via magic bytes) for proper UI rendering.
   - MLflow/W&B: uploaded as artifacts. File series include the step in the artifact name/path so steps remain distinguishable.
@@ -459,6 +486,7 @@ All records use `src/neptune_exporter/model.py::SCHEMA`:
   - ZenML: uploaded via `save_artifact()` and linked to Model Versions.
 - **Attribute names**:
   - Comet: sanitized to allowed pattern (`^[_a-zA-Z][_a-zA-Z0-9]*$`); invalid chars become `_`, and names are forced to start with a letter or underscore.
+  - GoodSeed: attribute paths are preserved as-is (GoodSeed uses `/` as path separator, matching Neptune). Skips Neptune-internal `sys/` attributes (`sys/id`, `sys/state`, `sys/owner`, `sys/size`, heartbeat/monitoring times) and `monitoring/*` attributes. `sys/name` is used for experiment name.
   - LitLogger: sanitized to allowed pattern (`^[a-zA-Z0-9_-]+$`); invalid chars become `_`. Experiment and teamspace names are truncated to 64 chars.
   - Minfx: Skips `sys/*` attributes except allowed ones (`sys/hostname`, `sys/tags`, `sys/group_tags`).
   - MLflow: sanitized to allowed chars (alphanumeric + `_-. /`), truncated at 250 chars.

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ All records use `src/neptune_exporter/model.py::SCHEMA`:
 
 - **Parameters** (`float`, `int`, `string`, `bool`, `datetime`, `string_set`):
   - Comet: logged as parameters with native types (string_set → list).
-  - GoodSeed: logged as configs with native types (datetime → ISO string, string_set → comma-separated string). Skips Neptune-internal `sys/` metadata (`sys/id`, `sys/state`, `sys/owner`, `sys/size`, `sys/ping_time`, `sys/running_time`, `sys/monitoring_time`) and `monitoring/*` attributes. `sys/name` is used as the experiment name.
+  - GoodSeed: logged as configs with native types (datetime → ISO string, string_set → comma-separated string). Skips Neptune-internal `sys/` metadata (`sys/id`, `sys/custom_run_id`, `sys/name`, `sys/state`, `sys/owner`, `sys/size`, `sys/ping_time`, `sys/running_time`, `sys/monitoring_time`). `sys/name` is used as the experiment name.
   - LitLogger: logged as experiment metadata (string key-value pairs, searchable/filterable in the UI).
   - Minfx: logged with native types (datetime → timestamp, string_set → StringSet). Preserves `sys/hostname`, `sys/tags`, and `sys/group_tags` from original data; other `sys/*` attributes are skipped as they're managed by Neptune.
   - MLflow: logged as params (values stringified by the client).
@@ -486,7 +486,7 @@ All records use `src/neptune_exporter/model.py::SCHEMA`:
   - ZenML: uploaded via `save_artifact()` and linked to Model Versions.
 - **Attribute names**:
   - Comet: sanitized to allowed pattern (`^[_a-zA-Z][_a-zA-Z0-9]*$`); invalid chars become `_`, and names are forced to start with a letter or underscore.
-  - GoodSeed: attribute paths are preserved as-is (GoodSeed uses `/` as path separator, matching Neptune). Skips Neptune-internal `sys/` attributes (`sys/id`, `sys/state`, `sys/owner`, `sys/size`, heartbeat/monitoring times) and `monitoring/*` attributes. `sys/name` is used for experiment name.
+  - GoodSeed: attribute paths are preserved as-is (GoodSeed uses `/` as path separator, matching Neptune). Skips Neptune-internal `sys/` attributes (`sys/id`, `sys/custom_run_id`, `sys/name`, `sys/state`, `sys/owner`, `sys/size`, heartbeat/monitoring times). `sys/name` is used for experiment name.
   - LitLogger: sanitized to allowed pattern (`^[a-zA-Z0-9_-]+$`); invalid chars become `_`. Experiment and teamspace names are truncated to 64 chars.
   - Minfx: Skips `sys/*` attributes except allowed ones (`sys/hostname`, `sys/tags`, `sys/group_tags`).
   - MLflow: sanitized to allowed chars (alphanumeric + `_-. /`), truncated at 250 chars.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ litlogger = [
 ]
 minfx = ["minfx"]
 pluto = ["pluto-ml>=0.0.2"]
+goodseed = ["goodseed"]
 
 [project.scripts]
 neptune-exporter = "neptune_exporter.main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ litlogger = [
 ]
 minfx = ["minfx"]
 pluto = ["pluto-ml>=0.0.2"]
-goodseed = ["goodseed"]
+goodseed = ["goodseed>=0.2.4"]
 
 [project.scripts]
 neptune-exporter = "neptune_exporter.main:main"

--- a/src/neptune_exporter/loaders/__init__.py
+++ b/src/neptune_exporter/loaders/__init__.py
@@ -71,6 +71,14 @@ except Exception:  # pragma: no cover - pluto is optional
     PlutoLoader = None  # type: ignore[misc,assignment]
     PLUTO_AVAILABLE = False  # type: ignore[misc,assignment]
 
+try:
+    from .goodseed_loader import GoodseedLoader
+
+    GOODSEED_AVAILABLE = True
+except Exception:  # pragma: no cover - goodseed is optional
+    GoodseedLoader = None  # type: ignore[misc,assignment]
+    GOODSEED_AVAILABLE = False  # type: ignore[misc,assignment]
+
 __all__ = ["DataLoader"]
 if MLFLOW_AVAILABLE:
     __all__.append("MLflowLoader")
@@ -86,3 +94,5 @@ if MINFX_AVAILABLE:
     __all__.append("MinfxLoader")
 if PLUTO_AVAILABLE:
     __all__.append("PlutoLoader")
+if GOODSEED_AVAILABLE:
+    __all__.append("GoodseedLoader")

--- a/src/neptune_exporter/loaders/__init__.py
+++ b/src/neptune_exporter/loaders/__init__.py
@@ -72,9 +72,7 @@ except Exception:  # pragma: no cover - pluto is optional
     PLUTO_AVAILABLE = False  # type: ignore[misc,assignment]
 
 try:
-    from .goodseed_loader import GoodseedLoader
-
-    GOODSEED_AVAILABLE = True
+    from .goodseed_loader import GoodseedLoader, GOODSEED_AVAILABLE
 except Exception:  # pragma: no cover - goodseed is optional
     GoodseedLoader = None  # type: ignore[misc,assignment]
     GOODSEED_AVAILABLE = False  # type: ignore[misc,assignment]

--- a/src/neptune_exporter/loaders/goodseed_loader.py
+++ b/src/neptune_exporter/loaders/goodseed_loader.py
@@ -1,0 +1,410 @@
+#
+# Copyright (c) 2025, Neptune Labs Sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loader for migrating Neptune data to GoodSeed experiment tracker."""
+
+import logging
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Dict, Generator, Optional
+
+import pandas as pd
+import pyarrow as pa
+
+from neptune_exporter.loaders.loader import DataLoader
+from neptune_exporter.types import ProjectId, TargetExperimentId, TargetRunId
+
+try:
+    import goodseed
+
+    GOODSEED_AVAILABLE = True
+except ImportError:
+    GOODSEED_AVAILABLE = False
+    goodseed = None  # type: ignore
+
+
+# Neptune sys/ attributes to skip (platform internals: identity, state, ownership, heartbeats).
+# Other attributes like sys/creation_time, sys/failed, sys/tags, sys/description pass through.
+_SKIP_SYS_ATTRIBUTES = {
+    "sys/id",
+    "sys/custom_run_id",
+    "sys/state",
+    "sys/owner",
+    "sys/size",
+    "sys/ping_time",
+    "sys/running_time",
+    "sys/monitoring_time",
+}
+
+# Neptune attribute types that map to GoodSeed configs
+_PARAM_TYPES = {"float", "int", "string", "bool", "datetime", "string_set"}
+
+# Neptune attribute types we log warnings for (unsupported)
+_FILE_TYPES = {"file", "file_series", "file_set", "artifact"}
+
+
+class GoodseedLoader(DataLoader):
+    """
+    Loads Neptune data from parquet files into GoodSeed local experiment tracker.
+
+    This loader migrates experiment data from Neptune to GoodSeed's local SQLite
+    storage. GoodSeed operates entirely locally with no server or authentication
+    required.
+
+    Neptune Concept -> GoodSeed Concept
+    ------------------------------------
+    - Project       -> Project (passed through as-is)
+    - Run           -> Run (SQLite file)
+    - Parameters    -> Configs (log_configs)
+    - Float Series  -> Metrics (log_metrics)
+    - String Series -> String Series (log_string_series)
+    - sys/name      -> experiment_name
+    - Files         -> Skipped (not supported)
+    - Histograms    -> Skipped (not supported)
+
+    Usage:
+        loader = GoodseedLoader()
+        loader.create_run(project_id, run_name)
+        loader.upload_run_data(data_generator, run_id, files_dir, step_multiplier)
+    """
+
+    def __init__(
+        self,
+        goodseed_home: Optional[str] = None,
+        goodseed_project: Optional[str] = None,
+        name_prefix: Optional[str] = None,
+        show_client_logs: bool = False,
+    ):
+        """
+        Initialize GoodSeed loader.
+
+        Args:
+            goodseed_home: Override for GoodSeed data directory (default: ~/.goodseed).
+                Can also be set via GOODSEED_HOME environment variable.
+            goodseed_project: Override project name for all imported runs. If not set,
+                uses the Neptune project ID directly.
+            name_prefix: Optional prefix for run names.
+            show_client_logs: Enable verbose logging (unused, kept for interface consistency).
+        """
+        if not GOODSEED_AVAILABLE:
+            raise RuntimeError(
+                "GoodSeed is not installed. Install with "
+                "`pip install 'neptune-exporter[goodseed]'` to use the GoodSeed loader."
+            )
+
+        self._goodseed_home = goodseed_home
+        self._goodseed_project = goodseed_project
+        self._name_prefix = name_prefix
+        self._logger = logging.getLogger(__name__)
+
+        # Active run state
+        self._active_run: Optional[Any] = None
+        self._current_run_id: Optional[TargetRunId] = None
+        self._pending_run: Optional[Dict[str, Any]] = None
+
+        # Track warnings to avoid spamming
+        self._warned_file_skip = False
+        self._warned_histogram_skip = False
+
+    def _get_run_name(self, run_name: str) -> str:
+        """Build a GoodSeed run name, optionally with prefix."""
+        if self._name_prefix:
+            return f"{self._name_prefix}_{run_name}"
+        return run_name
+
+    def _get_project(self, project_id: str) -> str:
+        """Determine the GoodSeed project name."""
+        if self._goodseed_project:
+            return self._goodseed_project
+        return project_id
+
+    def _convert_step(self, step: Decimal, step_multiplier: int) -> int:
+        """Convert Neptune decimal step to GoodSeed integer step."""
+        if step is None:
+            return 0
+        return int(float(step) * step_multiplier)
+
+    # DataLoader interface
+
+    def create_experiment(
+        self, project_id: ProjectId, experiment_name: str
+    ) -> TargetExperimentId:
+        """
+        Return experiment identifier.
+
+        GoodSeed doesn't have a separate experiment creation step - the experiment
+        name is set when creating a Run. We just return the name for later use.
+        """
+        return TargetExperimentId(experiment_name)
+
+    def find_run(
+        self,
+        project_id: ProjectId,
+        run_name: str,
+        experiment_id: Optional[TargetExperimentId],
+    ) -> Optional[TargetRunId]:
+        """
+        Check if a run already exists in GoodSeed.
+
+        Looks for the SQLite file at the expected path. If found, returns the
+        run ID so LoaderManager can skip re-importing.
+        """
+        from goodseed.config import get_run_db_path
+
+        gs_run_name = self._get_run_name(run_name)
+        gs_project = self._get_project(project_id)
+
+        db_path = get_run_db_path(gs_project, gs_run_name, self._goodseed_home)
+        if db_path.exists():
+            self._logger.info(
+                f"Run '{gs_run_name}' already exists in project '{gs_project}', skipping."
+            )
+            return TargetRunId(gs_run_name)
+        return None
+
+    def create_run(
+        self,
+        project_id: ProjectId,
+        run_name: str,
+        experiment_id: Optional[TargetExperimentId] = None,
+        parent_run_id: Optional[TargetRunId] = None,
+        fork_step: Optional[float] = None,
+        step_multiplier: Optional[int] = None,
+    ) -> TargetRunId:
+        """
+        Prepare a GoodSeed run for deferred creation.
+
+        Actual Run creation happens in upload_run_data so we can extract
+        sys/name from the data to use as experiment_name.
+        """
+        gs_run_name = self._get_run_name(run_name)
+        gs_project = self._get_project(project_id)
+
+        self._pending_run = {
+            "run_name": gs_run_name,
+            "project": gs_project,
+            "project_id": project_id,
+            "original_run_name": run_name,
+            "experiment_name": str(experiment_id) if experiment_id else None,
+            "parent_run_id": str(parent_run_id) if parent_run_id else None,
+            "fork_step": fork_step,
+        }
+
+        run_id = TargetRunId(gs_run_name)
+        self._current_run_id = run_id
+
+        self._logger.info(
+            f"Prepared GoodSeed run '{gs_run_name}' in project '{gs_project}'"
+        )
+        return run_id
+
+    def upload_run_data(
+        self,
+        run_data: Generator[pa.Table, None, None],
+        run_id: TargetRunId,
+        files_directory: Path,
+        step_multiplier: int,
+    ) -> None:
+        """
+        Upload all data for a single run to GoodSeed.
+
+        Processes data chunks from the parquet generator and dispatches each
+        row by attribute_type to the appropriate GoodSeed API.
+        """
+        if self._pending_run is None or self._current_run_id != run_id:
+            raise RuntimeError(f"Run {run_id} is not prepared. Call create_run first.")
+
+        try:
+            first_chunk = True
+            for run_data_part in run_data:
+                run_df = run_data_part.to_pandas()
+
+                if first_chunk:
+                    self._create_run_from_data(run_df)
+                    first_chunk = False
+
+                self._upload_parameters(run_df)
+                self._upload_metrics(run_df, step_multiplier)
+                self._upload_string_series(run_df, step_multiplier)
+                self._warn_skipped_types(run_df)
+
+            # Close the run
+            if self._active_run is not None:
+                self._active_run.close()
+                self._logger.info(f"Successfully uploaded run {run_id} to GoodSeed")
+
+        except Exception:
+            self._logger.error(f"Error uploading data for run {run_id}", exc_info=True)
+            if self._active_run is not None:
+                try:
+                    self._active_run.close(status="failed")
+                except Exception:
+                    pass
+            raise
+        finally:
+            self._active_run = None
+            self._current_run_id = None
+            self._pending_run = None
+            self._warned_file_skip = False
+            self._warned_histogram_skip = False
+
+    # Run creation
+
+    def _create_run_from_data(self, run_df: pd.DataFrame) -> None:
+        """Create the GoodSeed Run, extracting experiment_name from data if available."""
+        if self._pending_run is None:
+            raise RuntimeError("No pending run")
+
+        # Try to extract sys/name from data to use as experiment_name
+        experiment_name = self._pending_run["experiment_name"]
+        sys_name_rows = run_df[
+            (run_df["attribute_path"] == "sys/name")
+            & (run_df["attribute_type"] == "string")
+        ]
+        if not sys_name_rows.empty:
+            val = sys_name_rows.iloc[0]["string_value"]
+            if pd.notna(val):
+                experiment_name = str(val)
+
+        self._active_run = goodseed.Run(
+            experiment_name=experiment_name,
+            project=self._pending_run["project"],
+            run_name=self._pending_run["run_name"],
+            goodseed_home=self._goodseed_home,
+        )
+
+        # Log Neptune origin metadata as configs
+        origin_configs = {
+            "neptune/project_id": self._pending_run["project_id"],
+            "neptune/run_id": self._pending_run["original_run_name"],
+        }
+        if self._pending_run.get("parent_run_id"):
+            origin_configs["neptune/parent_run_id"] = self._pending_run["parent_run_id"]
+        if self._pending_run.get("fork_step") is not None:
+            origin_configs["neptune/fork_step"] = self._pending_run["fork_step"]
+
+        self._active_run.log_configs(origin_configs)
+
+    # Parameter upload
+
+    def _upload_parameters(self, run_df: pd.DataFrame) -> None:
+        """Upload Neptune parameters as GoodSeed configs."""
+        if self._active_run is None:
+            return
+
+        param_data = run_df[run_df["attribute_type"].isin(_PARAM_TYPES)]
+        if param_data.empty:
+            return
+
+        configs: Dict[str, Any] = {}
+        for _, row in param_data.iterrows():
+            attr_path = row["attribute_path"]
+
+            # Skip most sys/ attributes
+            if attr_path in _SKIP_SYS_ATTRIBUTES:
+                continue
+            # Skip monitoring/* attributes
+            if isinstance(attr_path, str) and attr_path.startswith("monitoring/"):
+                continue
+
+            value = self._extract_param_value(row)
+            if value is not None:
+                configs[attr_path] = value
+
+        if configs:
+            self._active_run.log_configs(configs)
+
+    def _extract_param_value(self, row: pd.Series) -> Any:
+        """Extract a typed value from a parameter row."""
+        attr_type = row["attribute_type"]
+
+        if attr_type == "float" and pd.notna(row["float_value"]):
+            return float(row["float_value"])
+        elif attr_type == "int" and pd.notna(row["int_value"]):
+            return int(row["int_value"])
+        elif attr_type == "string" and pd.notna(row["string_value"]):
+            return str(row["string_value"])
+        elif attr_type == "bool" and pd.notna(row["bool_value"]):
+            return bool(row["bool_value"])
+        elif attr_type == "datetime" and pd.notna(row["datetime_value"]):
+            return str(row["datetime_value"])
+        elif attr_type == "string_set" and row["string_set_value"] is not None:
+            return ",".join(row["string_set_value"])
+        return None
+
+    # Metrics upload
+
+    def _upload_metrics(self, run_df: pd.DataFrame, step_multiplier: int) -> None:
+        """Upload Neptune float_series as GoodSeed metrics."""
+        if self._active_run is None:
+            return
+
+        metrics_data = run_df[run_df["attribute_type"] == "float_series"]
+        if metrics_data.empty:
+            return
+
+        # Group by step to batch metrics at the same step
+        for _, row in metrics_data.iterrows():
+            if pd.notna(row["float_value"]) and pd.notna(row["step"]):
+                attr_path = row["attribute_path"]
+                step = self._convert_step(row["step"], step_multiplier)
+                value = float(row["float_value"])
+                self._active_run.log_metrics({attr_path: value}, step=step)
+
+    # String series upload
+
+    def _upload_string_series(self, run_df: pd.DataFrame, step_multiplier: int) -> None:
+        """Upload Neptune string_series as GoodSeed string series."""
+        if self._active_run is None:
+            return
+
+        series_data = run_df[run_df["attribute_type"] == "string_series"]
+        if series_data.empty:
+            return
+
+        for _, row in series_data.iterrows():
+            if pd.notna(row["string_value"]):
+                attr_path = row["attribute_path"]
+                step = (
+                    self._convert_step(row["step"], step_multiplier)
+                    if pd.notna(row["step"])
+                    else 0
+                )
+                value = str(row["string_value"])
+                self._active_run.log_string_series({attr_path: value}, step=step)
+
+    # Warnings for unsupported types
+
+    def _warn_skipped_types(self, run_df: pd.DataFrame) -> None:
+        """Log warnings for data types that cannot be imported to GoodSeed."""
+        if not self._warned_file_skip:
+            file_data = run_df[run_df["attribute_type"].isin(_FILE_TYPES)]
+            if not file_data.empty:
+                count = len(file_data)
+                self._logger.warning(
+                    f"Skipping {count} file attribute(s) - "
+                    f"GoodSeed does not support file storage."
+                )
+                self._warned_file_skip = True
+
+        if not self._warned_histogram_skip:
+            hist_data = run_df[run_df["attribute_type"] == "histogram_series"]
+            if not hist_data.empty:
+                count = len(hist_data)
+                self._logger.warning(
+                    f"Skipping {count} histogram attribute(s) - "
+                    f"GoodSeed does not support histograms."
+                )
+                self._warned_histogram_skip = True

--- a/src/neptune_exporter/loaders/goodseed_loader.py
+++ b/src/neptune_exporter/loaders/goodseed_loader.py
@@ -326,9 +326,6 @@ class GoodseedLoader(DataLoader):
             # Skip most sys/ attributes
             if attr_path in _SKIP_SYS_ATTRIBUTES:
                 continue
-            # Skip monitoring/* attributes
-            if isinstance(attr_path, str) and attr_path.startswith("monitoring/"):
-                continue
 
             value = self._extract_param_value(row)
             if value is not None:

--- a/src/neptune_exporter/loaders/goodseed_loader.py
+++ b/src/neptune_exporter/loaders/goodseed_loader.py
@@ -347,7 +347,7 @@ class GoodseedLoader(DataLoader):
         elif attr_type == "bool" and pd.notna(row.bool_value):
             return bool(row.bool_value)
         elif attr_type == "datetime" and pd.notna(row.datetime_value):
-            return str(row.datetime_value)
+            return pd.Timestamp(row.datetime_value).isoformat()
         elif attr_type == "string_set" and row.string_set_value is not None:
             return ",".join(row.string_set_value)
         return None

--- a/tests/unit/test_goodseed_loader.py
+++ b/tests/unit/test_goodseed_loader.py
@@ -1,0 +1,766 @@
+#
+# Copyright (c) 2025, Neptune Labs Sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import Mock, patch, call
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from neptune_exporter.loaders.goodseed_loader import GoodseedLoader
+from neptune_exporter import model
+
+
+def _make_loader(**kwargs):
+    """Create a GoodseedLoader with goodseed mocked as available."""
+    with patch("neptune_exporter.loaders.goodseed_loader.GOODSEED_AVAILABLE", True):
+        return GoodseedLoader(**kwargs)
+
+
+def _make_table(data: dict) -> pa.Table:
+    """Create a PyArrow table from a dict with all schema columns filled."""
+    n = len(next(iter(data.values())))
+    defaults = {
+        "project_id": ["test-project"] * n,
+        "run_id": ["RUN-1"] * n,
+        "attribute_path": [""] * n,
+        "attribute_type": [""] * n,
+        "step": [None] * n,
+        "timestamp": [None] * n,
+        "int_value": [None] * n,
+        "float_value": [None] * n,
+        "string_value": [None] * n,
+        "bool_value": [None] * n,
+        "datetime_value": [None] * n,
+        "string_set_value": [None] * n,
+        "file_value": [None] * n,
+        "histogram_value": [None] * n,
+    }
+    defaults.update(data)
+    df = pd.DataFrame(defaults)
+    return pa.Table.from_pandas(df, schema=model.SCHEMA)
+
+
+def _table_gen(*tables):
+    """Wrap tables in a generator as expected by upload_run_data."""
+    for t in tables:
+        yield t
+
+
+# Initialization
+
+
+def test_init_basic():
+    """Test basic initialization."""
+    loader = _make_loader()
+    assert loader._goodseed_home is None
+    assert loader._goodseed_project is None
+    assert loader._name_prefix is None
+
+
+def test_init_with_options():
+    """Test initialization with all options."""
+    loader = _make_loader(
+        goodseed_home="/tmp/gs",
+        goodseed_project="my-project",
+        name_prefix="import",
+    )
+    assert loader._goodseed_home == "/tmp/gs"
+    assert loader._goodseed_project == "my-project"
+    assert loader._name_prefix == "import"
+
+
+def test_init_raises_without_goodseed():
+    """Test that init raises when goodseed is not installed."""
+    with patch("neptune_exporter.loaders.goodseed_loader.GOODSEED_AVAILABLE", False):
+        with pytest.raises(RuntimeError, match="GoodSeed is not installed"):
+            GoodseedLoader()
+
+
+# Helper methods
+
+
+def test_get_run_name():
+    """Test run name generation."""
+    loader = _make_loader()
+    assert loader._get_run_name("RUN-123") == "RUN-123"
+
+
+def test_get_run_name_with_prefix():
+    """Test run name with prefix."""
+    loader = _make_loader(name_prefix="import")
+    assert loader._get_run_name("RUN-123") == "import_RUN-123"
+
+
+def test_get_project_default():
+    """Test project uses Neptune project ID by default."""
+    loader = _make_loader()
+    assert loader._get_project("workspace/my-project") == "workspace/my-project"
+
+
+def test_get_project_override():
+    """Test project override."""
+    loader = _make_loader(goodseed_project="custom-project")
+    assert loader._get_project("workspace/my-project") == "custom-project"
+
+
+def test_convert_step():
+    """Test decimal step conversion to integer."""
+    loader = _make_loader()
+    assert loader._convert_step(Decimal("1.5"), 1000) == 1500
+    assert loader._convert_step(Decimal("0"), 1) == 0
+    assert loader._convert_step(None, 1000) == 0
+
+
+# create_experiment
+
+
+def test_create_experiment():
+    """Test create_experiment returns experiment name."""
+    loader = _make_loader()
+    result = loader.create_experiment("test-project", "my-experiment")
+    assert result == "my-experiment"
+
+
+# find_run
+
+
+def test_find_run_not_found():
+    """Test find_run returns None when run doesn't exist."""
+    loader = _make_loader()
+    mock_path = Mock(spec=Path)
+    mock_path.exists.return_value = False
+    with patch("goodseed.config.get_run_db_path", return_value=mock_path):
+        result = loader.find_run("test-project", "RUN-123", None)
+        assert result is None
+
+
+def test_find_run_exists():
+    """Test find_run returns run ID when run exists."""
+    loader = _make_loader()
+    mock_path = Mock(spec=Path)
+    mock_path.exists.return_value = True
+    with patch("goodseed.config.get_run_db_path", return_value=mock_path):
+        result = loader.find_run("test-project", "RUN-123", None)
+        assert result == "RUN-123"
+
+
+# create_run
+
+
+def test_create_run():
+    """Test create_run stores pending run info."""
+    loader = _make_loader()
+    run_id = loader.create_run("workspace/project", "RUN-123", "my-experiment")
+
+    assert run_id == "RUN-123"
+    assert loader._pending_run is not None
+    assert loader._pending_run["run_name"] == "RUN-123"
+    assert loader._pending_run["project"] == "workspace/project"
+    assert loader._pending_run["experiment_name"] == "my-experiment"
+
+
+def test_create_run_with_prefix():
+    """Test create_run applies name prefix."""
+    loader = _make_loader(name_prefix="import")
+    run_id = loader.create_run("workspace/project", "RUN-123")
+
+    assert run_id == "import_RUN-123"
+    assert loader._pending_run["run_name"] == "import_RUN-123"
+
+
+def test_create_run_with_project_override():
+    """Test create_run uses project override."""
+    loader = _make_loader(goodseed_project="my-project")
+    loader.create_run("workspace/project", "RUN-123")
+
+    assert loader._pending_run["project"] == "my-project"
+
+
+def test_create_run_with_fork_info():
+    """Test create_run stores fork information."""
+    loader = _make_loader()
+    loader.create_run(
+        "workspace/project",
+        "RUN-123",
+        parent_run_id="RUN-100",
+        fork_step=42.0,
+    )
+
+    assert loader._pending_run["parent_run_id"] == "RUN-100"
+    assert loader._pending_run["fork_step"] == 42.0
+
+
+# upload_run_data - parameters
+
+
+def test_upload_parameters():
+    """Test uploading all parameter types as GoodSeed configs."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": [
+                "config/lr",
+                "config/epochs",
+                "config/name",
+                "config/debug",
+                "config/started",
+                "config/tags",
+            ],
+            "attribute_type": [
+                "float",
+                "int",
+                "string",
+                "bool",
+                "datetime",
+                "string_set",
+            ],
+            "float_value": [0.001, None, None, None, None, None],
+            "int_value": [None, 100, None, None, None, None],
+            "string_value": [None, None, "experiment-1", None, None, None],
+            "bool_value": [None, None, None, True, None, None],
+            "datetime_value": [
+                None,
+                None,
+                None,
+                None,
+                pd.Timestamp("2024-01-15 10:30:00", tz="UTC"),
+                None,
+            ],
+            "string_set_value": [None, None, None, None, None, ["tag1", "tag2"]],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1", "experiment")
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    # Should have been called at least twice: once for origin metadata, once for params
+    assert mock_run.log_configs.call_count >= 2
+
+    # Collect all logged configs across calls
+    all_configs = {}
+    for c in mock_run.log_configs.call_args_list:
+        all_configs.update(c[0][0])
+
+    assert all_configs["config/lr"] == 0.001
+    assert all_configs["config/epochs"] == 100
+    assert all_configs["config/name"] == "experiment-1"
+    assert all_configs["config/debug"] is True
+    assert all_configs["config/tags"] == "tag1,tag2"
+    # Neptune origin metadata
+    assert all_configs["neptune/project_id"] == "test-project"
+    assert all_configs["neptune/run_id"] == "RUN-1"
+
+
+def test_upload_skips_sys_attributes():
+    """Test that internal sys/ attributes are skipped but useful ones pass through."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": [
+                "sys/id",
+                "sys/state",
+                "sys/name",
+                "sys/creation_time",
+                "sys/modification_time",
+                "sys/trashed",
+                "sys/failed",
+                "config/lr",
+            ],
+            "attribute_type": [
+                "string",
+                "string",
+                "string",
+                "datetime",
+                "datetime",
+                "bool",
+                "bool",
+                "float",
+            ],
+            "string_value": ["RUN-1", "idle", "my-run", None, None, None, None, None],
+            "float_value": [None, None, None, None, None, None, None, 0.01],
+            "datetime_value": [
+                None,
+                None,
+                None,
+                pd.Timestamp("2024-01-15 10:00:00", tz="UTC"),
+                pd.Timestamp("2024-01-16 12:00:00", tz="UTC"),
+                None,
+                None,
+                None,
+            ],
+            "bool_value": [None, None, None, None, None, True, False, None],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1", "experiment")
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    all_configs = {}
+    for c in mock_run.log_configs.call_args_list:
+        all_configs.update(c[0][0])
+
+    # sys/id and sys/state should be skipped
+    assert "sys/id" not in all_configs
+    assert "sys/state" not in all_configs
+    # These sys/ attributes should be preserved
+    assert "sys/creation_time" in all_configs
+    assert "sys/modification_time" in all_configs
+    assert all_configs["sys/trashed"] is True
+    assert all_configs["sys/failed"] is False
+    assert all_configs["config/lr"] == 0.01
+
+
+def test_upload_skips_monitoring_attributes():
+    """Test that monitoring/* attributes are skipped."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": ["monitoring/gpu/0/memory", "config/lr"],
+            "attribute_type": ["float", "float"],
+            "float_value": [85.5, 0.01],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1")
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    all_configs = {}
+    for c in mock_run.log_configs.call_args_list:
+        all_configs.update(c[0][0])
+
+    assert "monitoring/gpu/0/memory" not in all_configs
+    assert all_configs["config/lr"] == 0.01
+
+
+# upload_run_data - metrics
+
+
+def test_upload_metrics():
+    """Test uploading float_series as GoodSeed metrics."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": ["train/loss", "train/loss", "train/acc"],
+            "attribute_type": ["float_series", "float_series", "float_series"],
+            "step": [Decimal("0"), Decimal("1"), Decimal("0")],
+            "float_value": [0.9, 0.5, 0.6],
+            "timestamp": [
+                pd.Timestamp("2024-01-15", tz="UTC"),
+                pd.Timestamp("2024-01-15", tz="UTC"),
+                pd.Timestamp("2024-01-15", tz="UTC"),
+            ],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1")
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    assert mock_run.log_metrics.call_count == 3
+
+    calls = mock_run.log_metrics.call_args_list
+    assert calls[0] == call({"train/loss": 0.9}, step=0)
+    assert calls[1] == call({"train/loss": 0.5}, step=1)
+    assert calls[2] == call({"train/acc": 0.6}, step=0)
+
+
+def test_upload_metrics_with_step_multiplier():
+    """Test that step_multiplier scales decimal steps to integers."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": ["loss"],
+            "attribute_type": ["float_series"],
+            "step": [Decimal("1.5")],
+            "float_value": [0.5],
+            "timestamp": [pd.Timestamp("2024-01-15", tz="UTC")],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1")
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1000
+        )
+
+    mock_run.log_metrics.assert_called_once_with({"loss": 0.5}, step=1500)
+
+
+def test_upload_metrics_skips_nan_values():
+    """Test that metric rows with NaN float_value or step are skipped."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": ["loss", "loss", "loss"],
+            "attribute_type": ["float_series", "float_series", "float_series"],
+            "step": [Decimal("0"), None, Decimal("2")],
+            "float_value": [0.9, 0.5, None],
+            "timestamp": [
+                pd.Timestamp("2024-01-15", tz="UTC"),
+                pd.Timestamp("2024-01-15", tz="UTC"),
+                pd.Timestamp("2024-01-15", tz="UTC"),
+            ],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1")
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    # Only the first row has both valid step and float_value
+    mock_run.log_metrics.assert_called_once_with({"loss": 0.9}, step=0)
+
+
+# upload_run_data - string series
+
+
+def test_upload_string_series():
+    """Test uploading string_series as GoodSeed string series."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": ["logs/info", "logs/info"],
+            "attribute_type": ["string_series", "string_series"],
+            "step": [Decimal("0"), Decimal("1")],
+            "string_value": ["Training started", "Epoch 1 done"],
+            "timestamp": [
+                pd.Timestamp("2024-01-15", tz="UTC"),
+                pd.Timestamp("2024-01-15", tz="UTC"),
+            ],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1")
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    assert mock_run.log_string_series.call_count == 2
+    calls = mock_run.log_string_series.call_args_list
+    assert calls[0] == call({"logs/info": "Training started"}, step=0)
+    assert calls[1] == call({"logs/info": "Epoch 1 done"}, step=1)
+
+
+def test_upload_string_series_missing_step_defaults_to_zero():
+    """Test that string series rows with missing step default to step=0."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": ["logs/info"],
+            "attribute_type": ["string_series"],
+            "step": [None],
+            "string_value": ["No step provided"],
+            "timestamp": [pd.Timestamp("2024-01-15", tz="UTC")],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1")
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    mock_run.log_string_series.assert_called_once_with(
+        {"logs/info": "No step provided"}, step=0
+    )
+
+
+# upload_run_data - skipped types
+
+
+def test_upload_warns_on_files():
+    """Test that file attributes produce a warning but don't crash the run."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": ["artifacts/model", "artifacts/checkpoint"],
+            "attribute_type": ["file", "file_series"],
+            "file_value": [{"path": "model.pt"}, {"path": "ckpt.pt"}],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1")
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    mock_run.close.assert_called_once()
+
+
+def test_upload_warns_on_histograms():
+    """Test that histogram attributes produce a warning but don't crash the run."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": ["hist/weights"],
+            "attribute_type": ["histogram_series"],
+            "step": [Decimal("1")],
+            "histogram_value": [{"type": "auto", "edges": [0.0, 1.0], "values": [5.0]}],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1")
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    mock_run.close.assert_called_once()
+
+
+# upload_run_data - experiment name from sys/name
+
+
+def test_experiment_name_from_sys_name():
+    """Test that sys/name is used as experiment_name for the GoodSeed Run."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": ["sys/name"],
+            "attribute_type": ["string"],
+            "string_value": ["my-experiment-name"],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ) as mock_run_class:
+        loader.create_run("test-project", "RUN-1")
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    mock_run_class.assert_called_once()
+    _, kwargs = mock_run_class.call_args
+    assert kwargs["experiment_name"] == "my-experiment-name"
+
+
+# upload_run_data - error handling
+
+
+def test_upload_not_prepared():
+    """Test that upload_run_data raises when create_run wasn't called."""
+    loader = _make_loader()
+
+    with pytest.raises(RuntimeError, match="not prepared"):
+        loader.upload_run_data(_table_gen(), "RUN-1", Path("/files"), step_multiplier=1)
+
+
+def test_upload_closes_run_on_error():
+    """Test that run is closed with 'failed' status on error."""
+    loader = _make_loader()
+    mock_run = Mock()
+    mock_run.log_configs.side_effect = [None, Exception("DB error")]
+
+    table = _make_table(
+        {
+            "attribute_path": ["config/lr"],
+            "attribute_type": ["float"],
+            "float_value": [0.01],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1")
+        with pytest.raises(Exception, match="DB error"):
+            loader.upload_run_data(
+                _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+            )
+
+    mock_run.close.assert_called_once_with(status="failed")
+
+
+def test_upload_cleans_up_state():
+    """Test that internal state is reset after upload (success or failure)."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": ["config/lr"],
+            "attribute_type": ["float"],
+            "float_value": [0.01],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1")
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    assert loader._active_run is None
+    assert loader._current_run_id is None
+    assert loader._pending_run is None
+
+
+# upload_run_data - multiple chunks
+
+
+def test_upload_multiple_chunks():
+    """Test that multiple data chunks are processed correctly."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    # First chunk: parameters + sys/name
+    table1 = _make_table(
+        {
+            "attribute_path": ["sys/name", "config/lr"],
+            "attribute_type": ["string", "float"],
+            "string_value": ["my-exp", None],
+            "float_value": [None, 0.01],
+        }
+    )
+
+    # Second chunk: metrics
+    table2 = _make_table(
+        {
+            "attribute_path": ["train/loss", "train/loss"],
+            "attribute_type": ["float_series", "float_series"],
+            "step": [Decimal("0"), Decimal("1")],
+            "float_value": [0.9, 0.5],
+            "timestamp": [
+                pd.Timestamp("2024-01-15", tz="UTC"),
+                pd.Timestamp("2024-01-15", tz="UTC"),
+            ],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run("test-project", "RUN-1")
+        loader.upload_run_data(
+            _table_gen(table1, table2), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    # Configs from chunk 1 + metrics from chunk 2
+    assert mock_run.log_configs.call_count >= 2  # origin + params
+    assert mock_run.log_metrics.call_count == 2
+    mock_run.close.assert_called_once()
+
+
+# upload_run_data - fork metadata as configs
+
+
+def test_upload_fork_metadata():
+    """Test that fork info is stored as Neptune origin configs."""
+    loader = _make_loader()
+    mock_run = Mock()
+
+    table = _make_table(
+        {
+            "attribute_path": ["config/lr"],
+            "attribute_type": ["float"],
+            "float_value": [0.01],
+        }
+    )
+
+    with patch(
+        "neptune_exporter.loaders.goodseed_loader.goodseed.Run",
+        return_value=mock_run,
+    ):
+        loader.create_run(
+            "test-project",
+            "RUN-1",
+            parent_run_id="RUN-0",
+            fork_step=50.0,
+        )
+        loader.upload_run_data(
+            _table_gen(table), "RUN-1", Path("/files"), step_multiplier=1
+        )
+
+    # First log_configs call should be origin metadata
+    first_configs = mock_run.log_configs.call_args_list[0][0][0]
+    assert first_configs["neptune/parent_run_id"] == "RUN-0"
+    assert first_configs["neptune/fork_step"] == 50.0

--- a/tests/unit/test_goodseed_loader.py
+++ b/tests/unit/test_goodseed_loader.py
@@ -13,22 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 from decimal import Decimal
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch, call
+from unittest.mock import Mock, patch, call
 
 import pandas as pd
 import pyarrow as pa
 import pytest
 
-# Mock goodseed before importing GoodseedLoader
-_goodseed_mock = MagicMock()
-sys.modules["goodseed"] = _goodseed_mock
-sys.modules["goodseed.config"] = _goodseed_mock.config
-
-from neptune_exporter.loaders.goodseed_loader import GoodseedLoader  # noqa: E402
-from neptune_exporter import model  # noqa: E402
+from neptune_exporter.loaders.goodseed_loader import GoodseedLoader
+from neptune_exporter import model
 
 
 def _make_loader(**kwargs):

--- a/tests/unit/test_goodseed_loader.py
+++ b/tests/unit/test_goodseed_loader.py
@@ -13,16 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from decimal import Decimal
 from pathlib import Path
-from unittest.mock import Mock, patch, call
+from unittest.mock import MagicMock, Mock, patch, call
 
 import pandas as pd
 import pyarrow as pa
 import pytest
 
-from neptune_exporter.loaders.goodseed_loader import GoodseedLoader
-from neptune_exporter import model
+# Mock goodseed before importing GoodseedLoader
+_goodseed_mock = MagicMock()
+sys.modules["goodseed"] = _goodseed_mock
+sys.modules["goodseed.config"] = _goodseed_mock.config
+
+from neptune_exporter.loaders.goodseed_loader import GoodseedLoader  # noqa: E402
+from neptune_exporter import model  # noqa: E402
 
 
 def _make_loader(**kwargs):

--- a/uv.lock
+++ b/uv.lock
@@ -896,6 +896,15 @@ wheels = [
 ]
 
 [[package]]
+name = "goodseed"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/68/14570940ccb5226032b355631f77f535c7ca6969b2537c9418caa8441a0e/goodseed-0.2.3.tar.gz", hash = "sha256:e806228d78e861c7e79a0dcb4f1e1bcfdb934724344d095bf0b51e9a3a191f68", size = 50595, upload-time = "2026-02-11T19:04:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/84/05998b7d564bd35ac40533d52c549fbaa2ddb3612f2975f4d2157c935ff1/goodseed-0.2.3-py3-none-any.whl", hash = "sha256:c85930c32ec20a8d28538402a2fac09ff0ded9b4d98117a07f48f25b85e5fd81", size = 17122, upload-time = "2026-02-11T19:04:22.539Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.45.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1971,6 +1980,9 @@ dependencies = [
 cometml = [
     { name = "comet-ml" },
 ]
+goodseed = [
+    { name = "goodseed" },
+]
 litlogger = [
     { name = "litlogger" },
     { name = "matplotlib" },
@@ -2005,6 +2017,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.0,<9.0.0" },
     { name = "comet-ml", marker = "extra == 'cometml'", specifier = ">=3.55.0" },
+    { name = "goodseed", marker = "extra == 'goodseed'" },
     { name = "litlogger", marker = "extra == 'litlogger'", specifier = ">=0.1.0,<0.2.0" },
     { name = "matplotlib", marker = "extra == 'litlogger'" },
     { name = "minfx", marker = "extra == 'minfx'" },
@@ -2017,7 +2030,7 @@ requires-dist = [
     { name = "wandb", marker = "extra == 'wandb'", specifier = ">=0.22.3,<1.0.0" },
     { name = "zenml", marker = "extra == 'zenml'", specifier = ">=0.90.0,<1.0.0" },
 ]
-provides-extras = ["mlflow", "wandb", "zenml", "cometml", "litlogger", "minfx", "pluto"]
+provides-extras = ["mlflow", "wandb", "zenml", "cometml", "litlogger", "minfx", "pluto", "goodseed"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -897,11 +897,11 @@ wheels = [
 
 [[package]]
 name = "goodseed"
-version = "0.2.3"
+version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/42/68/14570940ccb5226032b355631f77f535c7ca6969b2537c9418caa8441a0e/goodseed-0.2.3.tar.gz", hash = "sha256:e806228d78e861c7e79a0dcb4f1e1bcfdb934724344d095bf0b51e9a3a191f68", size = 50595, upload-time = "2026-02-11T19:04:24.495Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/98/65f2295b0d32655445a26f0904cec25668b5fbd41ac7dfdcd0fea34506e5/goodseed-0.2.4.tar.gz", hash = "sha256:9f6a116f40c380da09c66527c669a3e6a583d26469095f5fc829e2d05edba49b", size = 22553, upload-time = "2026-02-16T16:36:22.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/84/05998b7d564bd35ac40533d52c549fbaa2ddb3612f2975f4d2157c935ff1/goodseed-0.2.3-py3-none-any.whl", hash = "sha256:c85930c32ec20a8d28538402a2fac09ff0ded9b4d98117a07f48f25b85e5fd81", size = 17122, upload-time = "2026-02-11T19:04:22.539Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d7/26144dc67fbf5e88d08c9d5f81892f7583539298807e2aa9e9c84376da9f/goodseed-0.2.4-py3-none-any.whl", hash = "sha256:3d165557c90668c192b28db735514c640a1254bf7b39d0032de24379f12cc255", size = 16539, upload-time = "2026-02-16T16:36:21.695Z" },
 ]
 
 [[package]]
@@ -2017,7 +2017,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.0,<9.0.0" },
     { name = "comet-ml", marker = "extra == 'cometml'", specifier = ">=3.55.0" },
-    { name = "goodseed", marker = "extra == 'goodseed'" },
+    { name = "goodseed", marker = "extra == 'goodseed'", specifier = ">=0.2.4" },
     { name = "litlogger", marker = "extra == 'litlogger'", specifier = ">=0.1.0,<0.2.0" },
     { name = "matplotlib", marker = "extra == 'litlogger'" },
     { name = "minfx", marker = "extra == 'minfx'" },


### PR DESCRIPTION
Adds a loader for [GoodSeed](https://goodseed.ai), a local experiment tracker.

### What's included

- `GoodseedLoader` implementing the `DataLoader` interface
- CLI integration (`neptune-exporter load --loader goodseed`)
- Unit tests

### What gets imported

- Parameters (float, int, string, bool, datetime, string_set)
- Float series
- String series

Files and histograms are skipped with a warning since GoodSeed doesn't support those yet.

### Try it out

You can see the GoodSeed UI in action with a [live demo](https://goodseed.ai/app/demo/) - no install required. There's also a [Neptune demo](https://goodseed.ai/app/neptune) that connects directly to Neptune projects and renders them in the GoodSeed viewer.

After importing, run `goodseed serve` to start a local server and view your runs.

For more information about GoodSeed, see also the [GoodSeed docs](https://goodseed.ai/docs/).